### PR TITLE
Add expansions to assign_rest_call_to_workflow function

### DIFF
--- a/ncc_workflow.py
+++ b/ncc_workflow.py
@@ -73,7 +73,11 @@ def create_workflow(
 
 
 def assign_rest_call_to_workflow(
-    ncc_location: str, ncc_token: str, rest_call_id: str, workflow_id: str
+    ncc_location: str,
+    ncc_token: str,
+    rest_call_id: str,
+    workflow_id: str,
+    rest_call_name: str,
 ):
     success = False
     conn = http.client.HTTPSConnection(ncc_location)
@@ -127,6 +131,7 @@ def assign_rest_call_to_workflow(
                                 "restCallId": rest_call_id,
                                 "_working": False,
                                 "description": "Search Contacts",
+                                "expansions": {"restCallId": {"name": rest_call_name}},
                             },
                             "type": "restapi",
                             "_selected": True,

--- a/set_up_integration.py
+++ b/set_up_integration.py
@@ -130,7 +130,11 @@ def set_up_integration(ncc_location: str, ncc_token: str):
             f'Assigning "{search_contacts_name}" to "Test Workflow" workflow...', end=""
         )
         success = assign_rest_call_to_workflow(
-            ncc_location, ncc_token, search_contacts_rest_call_id, workflow_id
+            ncc_location,
+            ncc_token,
+            search_contacts_rest_call_id,
+            workflow_id,
+            search_contacts_name,
         )
         if success:
             print("success!")


### PR DESCRIPTION
While viewing a workitem, expansions help identify the REST API object used.